### PR TITLE
Update images to use volto-object-widget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS instructions
+
+This repository uses Docker Compose for running tests, linters and the development stack.
+
+- Use `./scripts/setup-docker.sh` once to pull images and build the frontend container. It falls back to plain `docker` commands if `docker compose` is not available.
+- Run tests with `make test` and lint the code with `yarn lint` or `make lint`.
+- These commands require Docker. Without Docker available they will fail.
+- No special instructions for documentation changes.

--- a/README.md
+++ b/README.md
@@ -27,10 +27,14 @@ Demo GIF
 
       git clone https://github.com/eea/volto-forest-policy.git
       cd volto-forest-policy
-      make
+      ./scripts/setup-docker.sh
       make start
 
 Go to http://localhost:3000
+
+The setup script will pull the Docker images and build the frontend container.
+If `docker compose` is not available, it prints the plain `docker` commands
+that can be used instead.
 
 ### Add volto-forest-policy to your Volto project
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "@eeacms/volto-eea-design-system",
     "@eeacms/volto-eea-website-theme",
     "@eeacms/volto-globalsearch",
-    "@eeacms/volto-searchlib"
+    "@eeacms/volto-searchlib",
+    "@eeacms/volto-object-widget"
   ],
   "dependencies": {
     "@eeacms/volto-datablocks": "*",
@@ -56,7 +57,8 @@
     "react-highlight-words": "^0.16.0",
     "react-image-gallery": "1.2.7",
     "react-lazy-load-image-component": "^1.5.0",
-    "redraft": "^0.10.2"
+    "redraft": "^0.10.2",
+    "@eeacms/volto-object-widget": "eea/volto-object-widget#develop"
   },
   "resolutions": {
     "timezone-groups": "0.8.0"

--- a/scripts/setup-docker.sh
+++ b/scripts/setup-docker.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Setup helper for volto-forest-policy development
+set -e
+
+PLONE_VERSION=${PLONE_VERSION:-6}
+VOLTO_VERSION=${VOLTO_VERSION:-17}
+ADDON_PATH=${ADDON_PATH:-volto-forest-policy}
+ADDON_NAME=${ADDON_NAME:-@eeacms/volto-forest-policy}
+
+if command -v "docker" >/dev/null 2>&1; then
+  if docker compose version >/dev/null 2>&1; then
+    echo "Using docker compose to build containers"
+    PLONE_VERSION=$PLONE_VERSION VOLTO_VERSION=$VOLTO_VERSION \
+      ADDON_NAME=$ADDON_NAME ADDON_PATH=$ADDON_PATH \
+      docker compose pull
+    PLONE_VERSION=$PLONE_VERSION VOLTO_VERSION=$VOLTO_VERSION \
+      ADDON_NAME=$ADDON_NAME ADDON_PATH=$ADDON_PATH \
+      docker compose build
+    echo
+    echo "Run 'docker compose up' to start the stack"
+  else
+    echo "docker compose not available. Falling back to plain docker commands"
+    docker pull eeacms/plone-backend:$PLONE_VERSION
+    docker pull eeacms/frontend-builder:$VOLTO_VERSION
+    docker build -t volto-forest-policy-frontend \
+      --build-arg ADDON_NAME=$ADDON_NAME \
+      --build-arg ADDON_PATH=$ADDON_PATH \
+      --build-arg VOLTO_VERSION=$VOLTO_VERSION .
+    cat <<EOM
+To start backend run:
+  docker run --rm -it -p 8080:8080 -e SITE=Plone eeacms/plone-backend:$PLONE_VERSION
+
+To start frontend run:
+  docker run --rm -it -p 3000:3000 -p 3001:3001 \
+    -v "$(pwd)":/app/src/addons/$ADDON_PATH \
+    -e RAZZLE_INTERNAL_API_PATH=http://localhost:8080/Plone \
+    -e RAZZLE_DEV_PROXY_API_PATH=http://localhost:8080/Plone \
+    volto-forest-policy-frontend
+EOM
+  fi
+else
+  echo "Docker is required but was not found." >&2
+  exit 1
+fi

--- a/src/components/manage/Blocks/ImageCards/Carousel.jsx
+++ b/src/components/manage/Blocks/ImageCards/Carousel.jsx
@@ -5,6 +5,7 @@ import { Placeholder } from 'semantic-ui-react';
 
 import ImageGallery from 'react-image-gallery';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
+import { getImageScaleParams } from '@eeacms/volto-object-widget/helpers';
 
 import 'react-image-gallery/styles/css/image-gallery.css';
 
@@ -14,14 +15,18 @@ class Carousel extends Component {
   }
 
   renderSlide = (card) => {
+    const preview = getImageScaleParams(
+      card.attachedimage,
+      this.props.data?.image_scale || 'preview',
+    );
     return (
       <div className="slider-slide">
         <LazyLoadImage
           className="slide-img"
-          height={600}
+          height={preview?.height || 600}
           effect="blur"
-          style={{ backgroundImage: `url(${card.attachedimage})` }}
-          width={'100%'}
+          style={{ backgroundImage: `url(${preview?.download})` }}
+          width={preview?.width || '100%'}
           visibleByDefault={true}
           placeholder={
             <Placeholder>

--- a/src/components/manage/Blocks/ImageCards/RoundTiled.jsx
+++ b/src/components/manage/Blocks/ImageCards/RoundTiled.jsx
@@ -1,18 +1,10 @@
 import cx from 'classnames';
 import { Link } from 'react-router-dom';
-import config from '@plone/volto/registry';
-import { flattenToAppURL } from '@plone/volto/helpers';
 import React, { useEffect } from 'react';
-
-export const getPath = (url) => new URL(url).pathname;
+import { getImageScaleParams } from '@eeacms/volto-object-widget/helpers';
 
 // TODO: the approach for the URL path generation is not correct, it does not
 // work on local;
-
-export const thumbUrl = (url) =>
-  (url || '').includes(config.settings.apiPath)
-    ? `${flattenToAppURL(url)}/@@images/image/preview`
-    : `${url}/@@images/image/preview`;
 
 export const Card = (props) => {
   const { title, link, attachedimage } = props; // text,
@@ -21,12 +13,19 @@ export const Card = (props) => {
     require('./css/roundtiled.less');
   });
 
+  const preview = getImageScaleParams(attachedimage, 'preview');
+
   return (
     <div className="card">
       {link ? (
         <>
           <Link to={link}>
-            <img src={thumbUrl(getPath(attachedimage))} alt={title} />
+            <img
+              src={preview?.download}
+              alt={title}
+              width={preview?.width}
+              height={preview?.height}
+            />
           </Link>
           <h5>
             <Link to={link}>{title}</Link>
@@ -34,7 +33,12 @@ export const Card = (props) => {
         </>
       ) : (
         <>
-          <img src={thumbUrl(getPath(attachedimage))} alt={title} />
+          <img
+            src={preview?.download}
+            alt={title}
+            width={preview?.width}
+            height={preview?.height}
+          />
           <h5>{title}</h5>
         </>
       )}

--- a/src/components/manage/Blocks/ImageCards/View.jsx
+++ b/src/components/manage/Blocks/ImageCards/View.jsx
@@ -8,6 +8,7 @@ import { compose } from 'redux';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { withRouter } from 'react-router-dom';
 import { injectIntl } from 'react-intl';
+import { getImageScaleParams } from '@eeacms/volto-object-widget/helpers';
 
 import './styles.less';
 
@@ -18,10 +19,6 @@ const alignmentTypes = {
   full: 'left',
 };
 
-export const getScaleUrl = (url, size) =>
-  (url || '').includes(config.settings.apiPath)
-    ? `${flattenToAppURL(url.replace('/api', ''))}/@@images/image/${size}`
-    : `${url.replace('/api', '')}/@@images/image/${size}`;
 
 const Cards = (props) => {
   const { data, editable, history } = props;
@@ -35,17 +32,16 @@ const Cards = (props) => {
 
   const makeImage = (item) => {
     const { attachedimage } = item;
+    const preview = getImageScaleParams(
+      attachedimage,
+      image_scale || 'preview',
+    );
     return (
       <img
         className="cards-tile-image"
-        src={
-          attachedimage
-            ? getScaleUrl(
-                flattenToAppURL(attachedimage),
-                image_scale || 'preview',
-              )
-            : DefaultImageSVG
-        }
+        src={preview?.download || DefaultImageSVG}
+        width={preview?.width}
+        height={preview?.height}
         alt={item.title}
       />
     );


### PR DESCRIPTION
## Summary
- add `@eeacms/volto-object-widget` addon and dependency
- use `getImageScaleParams` helper when rendering attached images
- document a setup helper script for local docker builds
- add AGENTS instructions with docker-based testing guidance

## Testing
- `make test` *(fails: docker not found)*
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6855247cced483259f3096e678691dd7